### PR TITLE
Update OpenTelemetry

### DIFF
--- a/k8s/environment/jaeger.all-in-one.yaml
+++ b/k8s/environment/jaeger.all-in-one.yaml
@@ -44,25 +44,55 @@ items:
           -   env:
               - name: COLLECTOR_ZIPKIN_HTTP_PORT
                 value: "9411"
-              image: jaegertracing/all-in-one:1.30
+              - name: COLLECTOR_OTLP_ENABLED
+                value: "true"
+              image: jaegertracing/all-in-one:1.50
               name: jaeger
               ports:
-                - containerPort: 5775
+                # Agent ports
+                - name: zipkin-thrift
+                  containerPort: 5775
                   protocol: UDP
-                - containerPort: 6831
+                - name: thrift-compact
+                  containerPort: 6831
                   protocol: UDP
-                - containerPort: 6832
+                - name: thrift-binary
+                  containerPort: 6832
                   protocol: UDP
-                - containerPort: 5778
+                - name: configs
+                  containerPort: 5778
                   protocol: TCP
-                - containerPort: 16686
+                # Jaeger Frontend
+                - name: frontend
+                  containerPort: 16686
                   protocol: TCP
-                - containerPort: 9411
+                # Collector ports
+                - name: zipkin
+                  containerPort: 9411
+                  protocol: TCP
+                - name: jaeger-tchannel
+                  containerPort: 14267
+                  protocol: TCP
+                - name: jaeger-thrift
+                  containerPort: 14268
+                  protocol: TCP
+                - name: model-proto
+                  containerPort: 14250
+                  protocol: TCP
+                - name: otlp-grpc
+                  containerPort: 4317
+                  protocol: TCP
+                - name: otlp-http
+                  containerPort: 4318
+                  protocol: TCP
+                # Collector metric ports
+                - name: metrics
+                  containerPort: 14269
                   protocol: TCP
               readinessProbe:
                 httpGet:
                   path: "/"
-                  port: 14269
+                  port: metrics
                 initialDelaySeconds: 5
 - apiVersion: v1
   kind: Service
@@ -78,7 +108,7 @@ items:
       - name: query-http
         port: 16686
         protocol: TCP
-        targetPort: 16686
+        targetPort: frontend
     selector:
       app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: all-in-one
@@ -95,15 +125,23 @@ items:
     - name: jaeger-collector-tchannel
       port: 14267
       protocol: TCP
-      targetPort: 14267
+      targetPort: jaeger-tchannel
     - name: jaeger-collector-http
       port: 14268
       protocol: TCP
-      targetPort: 14268
+      targetPort: jaeger-thrift
     - name: jaeger-collector-zipkin
       port: 9411
       protocol: TCP
-      targetPort: 9411
+      targetPort: zipkin
+    - name: jaeger-collector-otlp-grpc
+      port: 4317
+      protocol: TCP
+      targetPort: otlp-grpc
+    - name: jaeger-collector-otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: otlp-http
     selector:
       app.kubernetes.io/name: jaeger
       app.kubernetes.io/component: all-in-one
@@ -121,19 +159,19 @@ items:
     - name: agent-zipkin-thrift
       port: 5775
       protocol: UDP
-      targetPort: 5775
+      targetPort: zipkin-thrift
     - name: agent-compact
       port: 6831
       protocol: UDP
-      targetPort: 6831
+      targetPort: thrift-compact
     - name: agent-binary
       port: 6832
       protocol: UDP
-      targetPort: 6832
+      targetPort: thrift-binary
     - name: agent-configs
       port: 5778
       protocol: TCP
-      targetPort: 5778
+      targetPort: configs
     clusterIP: None
     selector:
       app.kubernetes.io/name: jaeger
@@ -151,7 +189,7 @@ items:
     - name: jaeger-collector-zipkin
       port: 9411
       protocol: TCP
-      targetPort: 9411
+      targetPort: zipkin
     clusterIP: None
     selector:
       app.kubernetes.io/name: jaeger

--- a/k8s/services/petabridge.phobos.web.yaml
+++ b/k8s/services/petabridge.phobos.web.yaml
@@ -72,10 +72,10 @@ spec:
             configMapKeyRef:
               name: pb-configs
               key: environment
-        - name: JAEGER_AGENT_HOST
-          value: "jaeger-agent"    
-        - name: JAEGER_AGENT_PORT
-          value: "6832"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://jaeger-collector:4317"
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: "grpc"
         - name: JAEGER_SAMPLER_PARAM
           value: "1"
         - name: SEQ_SERVICE_HOST 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,8 +20,7 @@ Upgraded to Phobos 2.0.6</PackageReleaseNotes>
     <XunitRunnerVersion>2.5.0</XunitRunnerVersion>
     <TestSdkVersion>17.6.3</TestSdkVersion>
     <PbmVersion>1.3.2</PbmVersion>
-    <OTelVersion>1.5.1</OTelVersion>
-    <OTelExporterVersion>1.5.1</OTelExporterVersion>
-    <OTelInstrumentationVersion>1.0.0-rc9.14</OTelInstrumentationVersion>
+    <OTelVersion>1.6.0</OTelVersion>
+    <OTelInstrumentationVersion>1.5.1-beta.1</OTelInstrumentationVersion>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,8 +21,8 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OTelVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OTelInstrumentationVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OTelInstrumentationVersion)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Jaeger" Version="$(OTelExporterVersion)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OTelVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
   </ItemGroup>
   <!-- Serilog Package Versions -->
   <ItemGroup>

--- a/src/Petabridge.Phobos.Web/Petabridge.Phobos.Web.csproj
+++ b/src/Petabridge.Phobos.Web/Petabridge.Phobos.Web.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
-        <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
         <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
         <PackageReference Include="Serilog.AspNetCore" />
         <PackageReference Include="Serilog.Sinks.Console" />

--- a/src/Petabridge.Phobos.Web/Startup.cs
+++ b/src/Petabridge.Phobos.Web/Startup.cs
@@ -32,18 +32,18 @@ namespace Petabridge.Phobos.Web
 {
     public class Startup
     {
-        /// <summary>
-        ///     Name of the <see cref="Environment" /> variable used to direct Phobos' Jaeger
-        ///     output.
-        ///     See https://github.com/jaegertracing/jaeger-client-csharp for details.
-        /// </summary>
-        public const string JaegerAgentHostEnvironmentVar = "JAEGER_AGENT_HOST";
-
-        public const string JaegerEndpointEnvironmentVar = "JAEGER_ENDPOINT";
-
-        public const string JaegerAgentPortEnvironmentVar = "JAEGER_AGENT_PORT";
-
-        public const int DefaultJaegerAgentPort = 6832;
+        // OpenTelemetry.Exporter.OpenTelemetryProtocol exporter supports several environment variables
+        // that can be used to configure the exporter instance:
+        //
+        // * OTEL_EXPORTER_OTLP_ENDPOINT 
+        // * OTEL_EXPORTER_OTLP_HEADERS
+        // * OTEL_EXPORTER_OTLP_TIMEOUT
+        // * OTEL_EXPORTER_OTLP_PROTOCOL
+        //
+        // Please read https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/
+        // for further information.
+        //
+        // Note that OTEL_EXPORTER_OTLP_PROTOCOL only supports "grpc" and "http/protobuf"
 
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
@@ -72,10 +72,7 @@ namespace Petabridge.Phobos.Web
                         {
                             options.Filter = context => !context.Request.Path.StartsWithSegments("/metrics");
                         })
-                        .AddJaegerExporter(opt =>
-                        {
-                            opt.AgentHost = Environment.GetEnvironmentVariable(JaegerAgentHostEnvironmentVar) ?? "localhost";
-                        });
+                        .AddOtlpExporter();
                 })
                 .WithMetrics(builder =>
                 {


### PR DESCRIPTION
## Changes

* Bump OpenTelemetry.Exporter.Prometheus.AspNetCore from 1.4.0-rc.4 to 1.6.0-rc.1
* Remove OpenTelemetry.Exporter.Jaeger
* Add OpenTelemetry,Exporter.OpenTelemetryProtocol 1.6.0
* Change `Startup.cs` from using Jaeger specific configuration to OTLP configuration
* Change Kubernetes yaml files:
  * [Jaeger] Use port names
  * [Jaeger] Expose the new OTLP ports
  * [Akka-Web] Convert old Jaeger env vars to OTLP env vars